### PR TITLE
fix: address code quality issues in CPF/CNPJ validation

### DIFF
--- a/src/cnpj.ts
+++ b/src/cnpj.ts
@@ -12,7 +12,7 @@ const INVALID: Array<string> = [
 ]
 
 const Strip = (cnpj: string): string => cnpj
-	? cnpj.trim().replace(/[./-]/g, '')
+	? cnpj.trim().replace(/[^A-Za-z0-9]/g, '')
 	: ''
 
 const Format = (cnpj: string): string =>
@@ -32,6 +32,8 @@ const Format = (cnpj: string): string =>
 		.filter(e => e)
 		.join('-')
 
+const charToValue = (char: string): number => char.toUpperCase().charCodeAt(0) - 48
+
 const ValidateDigit = (cnpj: string, offset: number = 0): boolean => {
 	const factors: Array<number> = offset === 0
 		? [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
@@ -40,11 +42,11 @@ const ValidateDigit = (cnpj: string, offset: number = 0): boolean => {
 	const firstDigits: Array<number> = cnpj
 		.slice(0, 12 + offset)
 		.split('')
-		.map(e => Number.isInteger(e) ? Number(e) : e.toLocaleUpperCase().charCodeAt(0) - 48)
+		.map(charToValue)
 	const lastDigits: Array<number> = cnpj
 		.slice(12, 14)
 		.split('')
-		.map(e => Number.isInteger(e) ? Number(e) : e.toLocaleUpperCase().charCodeAt(0) - 48)
+		.map(charToValue)
 
 	const multiplied: number = firstDigits
 		.reduce((acc, curr, idx) => acc + curr * (factors[idx]), 0)

--- a/src/cpf.ts
+++ b/src/cpf.ts
@@ -9,7 +9,6 @@ const INVALID: Array<string> = [
   "77777777777",
   "88888888888",
   "99999999999",
-  "12345678909",
 ];
 
 const Strip = (cpf: string): string =>

--- a/tests/cnpj.test.ts
+++ b/tests/cnpj.test.ts
@@ -4,6 +4,10 @@ describe('CNPJ', () => {
   test('Strips the supplied CNPJ', () => {
     expect(CNPJ.Strip('30.306.294/0001-45')).toMatch('30306294000145')
   })
+  test('Strips CNPJ with spaces and other characters', () => {
+    expect(CNPJ.Strip(' 30 306 294 0001 45 ')).toMatch('30306294000145')
+    expect(CNPJ.Strip('30_306_294_0001_45')).toMatch('30306294000145')
+  })
   test('Returns an empty string for falsy strip values', () => {
     expect(CNPJ.Strip('')).toMatch('')
   })
@@ -80,4 +84,3 @@ describe('CNPJ', () => {
 
   })
 })
-

--- a/tests/cpf.test.ts
+++ b/tests/cpf.test.ts
@@ -22,7 +22,9 @@ describe('CPF', () => {
     expect(CPF.Validate('88888888888')).toBeFalsy()
     expect(CPF.Validate('99999999999')).toBeFalsy()
     expect(CPF.Validate('17457482817')).toBeFalsy()
-    expect(CPF.Validate('12345678909')).toBeFalsy()
+  })
+  test('Validates sequential CPF 12345678909 (valid by algorithm)', () => {
+    expect(CPF.Validate('12345678909')).toBeTruthy()
   })
   test('Invalidates Weird CPF Inputs', () => {
     expect(CPF.Validate('001#7%00860')).toBeFalsy()
@@ -65,4 +67,3 @@ describe('CPF', () => {
     expect(CPF.Validate('426781708', false)).toBeFalsy()
   })
 })
-


### PR DESCRIPTION
# Code Quality Improvements

Hi @julioakira! First of all, great library — clean API and good alphanumeric CNPJ support. We're using it in production and found a few issues during our code review. Here are the fixes:

## Changes

### 1. Fix `Number.isInteger` dead code branch in `src/cnpj.ts`

**Before:**
```ts
.map(e => Number.isInteger(e) ? Number(e) : e.toLocaleUpperCase().charCodeAt(0) - 48)
```

`Number.isInteger(e)` always returns `false` when `e` is a `string` (from `.split('')`), so the `Number(e)` branch is **never executed**. The code works by coincidence because `charCodeAt(0) - 48` happens to produce correct values for digits too (`'0' → 0`, `'9' → 9`).

**After:**
Extracted a `charToValue` helper and used `.map(charToValue)` directly — cleaner and makes the intent explicit.

### 2. Fix CNPJ `Strip` to handle all non-alphanumeric characters

**Before:**
```ts
cnpj.trim().replace(/[./-]/g, '')
```

Only removes `.`, `/` and `-`. If a CNPJ is pasted with spaces, underscores, or other characters, they remain in the string and cause validation to fail.

**After:**
```ts
cnpj.trim().replace(/[^A-Za-z0-9]/g, '')
```

Note: Can't use `\D` here since alphanumeric CNPJs contain letters.

### 3. Remove `12345678909` from CPF `INVALID` list

This CPF is **mathematically valid** per the módulo 11 algorithm. Hardcoding it as invalid can cause false negatives. The all-same-digits patterns (`00000000000`, `11111111111`, etc.) are legitimately invalid because they're known non-issued patterns, but `12345678909` doesn't fall in that category.

### 4. Test updates

- Added test for `CNPJ.Strip` with spaces and underscores
- Updated CPF test: `12345678909` is now expected to be valid
- Moved it to its own test case with descriptive name

## Summary

| Fix | Impact |
|-----|--------|
| `Number.isInteger` dead branch | No behavioral change (was already working by coincidence) — code clarity |
| CNPJ `Strip` regex | Fixes edge case where CNPJs with spaces/special chars fail validation |
| CPF `12345678909` | Fixes false negative for a valid CPF |